### PR TITLE
Compatibility with Big Sur privacy options

### DIFF
--- a/Bluetility.xcodeproj/project.pbxproj
+++ b/Bluetility.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D85908F22427E34700CBECC9 /* Debug.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 			};
 			name = Debug;
 		};

--- a/Bluetility/Info.plist
+++ b/Bluetility/Info.plist
@@ -30,5 +30,7 @@
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Please allow Bluetooth access to connect to devices.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Hello,

In order to succesfully run this application on Big Sur, I had to enable codesigning and provide an usage description key.

If the usage key is not provided, the TCC system will kill the application, and if codesigning is not enabled, the `CBCentralManager` would never transition to the `.poweredOn` state.