### PR TITLE
Fix Xcode deprecation issues

### DIFF
--- a/Bluetility.xcodeproj/project.pbxproj
+++ b/Bluetility.xcodeproj/project.pbxproj
@@ -142,7 +142,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = "Joseph Ross";
 				TargetAttributes = {
 					374931861BF169C90087E39F = {
@@ -159,10 +159,9 @@
 			};
 			buildConfigurationList = 374931821BF169C90087E39F /* Build configuration list for PBXProject "Bluetility" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -226,6 +225,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D85908F22427E34700CBECC9 /* Debug.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 			};
 			name = Debug;
 		};
@@ -233,6 +233,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D85908F32427E34700CBECC9 /* Release.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 			};
 			name = Release;
 		};
@@ -248,6 +250,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D85908F32427E34700CBECC9 /* Release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
 			};
 			name = Release;
 		};

--- a/Bluetility.xcodeproj/xcshareddata/xcschemes/Bluetility Debug.xcscheme
+++ b/Bluetility.xcodeproj/xcshareddata/xcschemes/Bluetility Debug.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Bluetility.xcodeproj/xcshareddata/xcschemes/Bluetility Release.xcscheme
+++ b/Bluetility.xcodeproj/xcshareddata/xcschemes/Bluetility Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Bluetility/Device.swift
+++ b/Bluetility/Device.swift
@@ -8,7 +8,7 @@
 
 import CoreBluetooth
 
-protocol DeviceDelegate: class {
+protocol DeviceDelegate: AnyObject {
     func deviceDidConnect(_ device: Device)
     func deviceDidDisconnect(_ device: Device)
     func deviceDidUpdateName(_ device: Device)

--- a/Bluetility/LogViewController.swift
+++ b/Bluetility/LogViewController.swift
@@ -32,7 +32,7 @@ class LogViewController: NSViewController {
         let data = data ?? characteristic.value ?? Data()
         let hexString = data.hexString
         appendLogText("UUID \(characteristic.uuid.uuidString) \(operationType) Value: 0x\(hexString)")
-        let logEntry = LogEntry(serviceUUID: characteristic.service.uuid.uuidString,
+        let logEntry = LogEntry(serviceUUID: characteristic.service!.uuid.uuidString,
             charUUID: characteristic.uuid.uuidString,
             operation: operationType,
             data: hexString,

--- a/Bluetility/Scanner.swift
+++ b/Bluetility/Scanner.swift
@@ -8,7 +8,7 @@
 
 import CoreBluetooth;
 
-protocol ScannerDelegate: class {
+protocol ScannerDelegate: AnyObject {
     func scanner(_ scanner: Scanner, didUpdateDevices: [Device])
 }
 


### PR DESCRIPTION
Hello! Thanks for writing Bluetility. I'm using it to debug a BLE connection to a hardware device. I used to work on LightBlue at Punch Through, so I'm glad to see you keeping the torch lit :blush:

This PR implements fixes to resolve build errors and warnings with Xcode 13.2.1:

* Replace protocols declared with `class` as `AnyObject`
* Mandatory unwrap of `characteristic.service!` when accessing UUID
* Apply Xcode project autofixes

Please feel free to take or leave any of these fixes as suits your workflow. Thanks again.