### PR TITLE
feat: search bar for uuid and friendlyName

### DIFF
--- a/Bluetility/Base.lproj/Main.storyboard
+++ b/Bluetility/Base.lproj/Main.storyboard
@@ -248,11 +248,24 @@
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
                         <toolbar key="toolbar" implicitIdentifier="533C158D-7680-47F3-990F-C93EB5726D4D" autosavesConfiguration="NO" displayMode="iconAndLabel" sizeMode="regular" id="Apq-FO-k1s">
                             <allowedToolbarItems>
+                                <toolbarItem implicitItemIdentifier="AF74279A-5C2D-4C8B-AF10-E4118D9C1B93" label="Search" paletteLabel="Search" sizingBehavior="auto" id="Lqj-o0-euH">
+                                    <nil key="toolTip"/>
+                                    <searchField key="view" wantsLayer="YES" verticalHuggingPriority="750" textCompletion="NO" id="4TR-Xo-VuE">
+                                        <rect key="frame" x="0.0" y="14" width="96" height="22"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Identifier, Service UUID" usesSingleLineMode="YES" bezelStyle="round" id="mID-HJ-2yX">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </searchFieldCell>
+                                    </searchField>
+                                </toolbarItem>
                                 <toolbarItem implicitItemIdentifier="40F96AE3-F3F8-449C-AC48-175219A4BF4E" label="Refresh" paletteLabel="Refresh" tag="-1" image="Refresh" sizingBehavior="auto" id="kSv-rP-wzc"/>
                                 <toolbarItem implicitItemIdentifier="660AAC15-A283-4910-BA13-9D6F5BC92C9B" label="Sort" paletteLabel="Sort" tag="-1" image="SortBySignal" sizingBehavior="auto" id="kSU-oa-g28"/>
                                 <toolbarItem implicitItemIdentifier="2362131C-9542-43CD-AC53-E48E1171B9D0" label="Log" paletteLabel="Log" tag="-1" image="Logs" sizingBehavior="auto" id="K8I-0P-t4B" userLabel="Log"/>
                             </allowedToolbarItems>
                             <defaultToolbarItems>
+                                <toolbarItem reference="Lqj-o0-euH"/>
                                 <toolbarItem reference="kSv-rP-wzc"/>
                                 <toolbarItem reference="kSU-oa-g28"/>
                                 <toolbarItem reference="K8I-0P-t4B"/>
@@ -265,6 +278,7 @@
                     <connections>
                         <outlet property="logItem" destination="K8I-0P-t4B" id="HfQ-HO-M2w"/>
                         <outlet property="refreshItem" destination="kSv-rP-wzc" id="Wcr-u6-W4G"/>
+                        <outlet property="searchItemField" destination="4TR-Xo-VuE" id="3Ii-55-fuu"/>
                         <outlet property="sortItem" destination="kSU-oa-g28" id="sEB-Qm-tuA"/>
                         <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
                     </connections>

--- a/Bluetility/BluetilityWindowController.swift
+++ b/Bluetility/BluetilityWindowController.swift
@@ -15,6 +15,7 @@ class BluetilityWindowController: NSWindowController {
     @IBOutlet var refreshItem: NSToolbarItem!
     @IBOutlet var sortItem: NSToolbarItem!
     @IBOutlet var logItem: NSToolbarItem!
+    @IBOutlet var searchItemField: NSSearchField!
     
     override func windowDidLoad() {
         super.windowDidLoad()
@@ -35,6 +36,17 @@ class BluetilityWindowController: NSWindowController {
         logItem.action = #selector(ViewController.logPressed(_:))
         sortItem.action = #selector(ViewController.sortPressed(_:))
         refreshItem.action = #selector(ViewController.refreshPressed(_:))
-        
+        searchItemField.delegate = self
     }
 }
+
+extension BluetilityWindowController: NSSearchFieldDelegate {
+    func controlTextDidChange(_ obj: Notification) {
+        guard let searchField = obj.object as? NSSearchField, searchField == searchItemField else {
+            return
+        }
+        
+        viewController?.searchTextDidChange(value: searchField.stringValue)
+    }
+}
+

--- a/Bluetility/Scanner.swift
+++ b/Bluetility/Scanner.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Joseph Ross. All rights reserved.
 //
 
-import CoreBluetooth;
+import CoreBluetooth
 
 protocol ScannerDelegate: AnyObject {
     func scanner(_ scanner: Scanner, didUpdateDevices: [Device])


### PR DESCRIPTION
Hi Ross,

Thanks for this fantastic tool. It helps a lot in understanding the behavior of your peripherals!

In the work that I'm doing our devices can be identified by service UUID. 
Since there are a lot of devices around me it helps me a lot if I can filter them by service UUID so I can quickly identify the correct device when I'm refreshing.

[![Image from Gyazo](https://i.gyazo.com/a5c0318b385603ceb3155ae2d6afa4ba.gif)](https://gyazo.com/a5c0318b385603ceb3155ae2d6afa4ba)

I'm not an Apple OS developer, so lemme know if I can do anything to improve this code. 

Thanks in advance.