### PR TITLE
fix for context menu issue #31

### DIFF
--- a/Bluetility/PasteboardBrowser.swift
+++ b/Bluetility/PasteboardBrowser.swift
@@ -40,10 +40,8 @@ class PasteboardBrowser: NSBrowser {
     }
     
     override func menu(for event: NSEvent) -> NSMenu? {
-        let point = event.locationInWindow
-        var row: Int = 0
-        var column: Int = 0
-        guard getRow(&row, column: &column, for: point) else { return nil }
+        let column = selectedColumn
+        let row = selectedRow(inColumn: column)
         selectRow(row, inColumn: column)
         self.sendAction()
         


### PR DESCRIPTION
This fixes the issue where:
When right clicking in the second column, the first 2 rows can not show the menu at all.
Then the third row show a menu for context of row 1.
The fourth row show a menu for context of row 2.
[![Issue video](https://i.gyazo.com/71a053da3ff8d40e9a9f6815dd1fb67e.gif)](https://gyazo.com/71a053da3ff8d40e9a9f6815dd1fb67e)

Only tested on MacOS Ventura 13.4.1