### PR TITLE
Fix context menu issue by converting NSWindow point to be relative to the NSBrowser.  Fixes #31.

### DIFF
--- a/Bluetility/PasteboardBrowser.swift
+++ b/Bluetility/PasteboardBrowser.swift
@@ -40,10 +40,11 @@ class PasteboardBrowser: NSBrowser {
     }
     
     override func menu(for event: NSEvent) -> NSMenu? {
-        let point = event.locationInWindow
+        let windowPoint = event.locationInWindow
+        let viewPoint = self.convert(windowPoint, from: window?.contentView)
         var row: Int = 0
         var column: Int = 0
-        guard getRow(&row, column: &column, for: point) else { return nil }
+        guard getRow(&row, column: &column, for: viewPoint) else { return nil }
         selectRow(row, inColumn: column)
         self.sendAction()
         


### PR DESCRIPTION
![context-menu-fix](https://github.com/jnross/Bluetility/assets/798990/54a05041-5f46-496b-9ad4-cf14d134ce3f)
